### PR TITLE
Refactor/implement a skeleton placeholder for product images on product details page

### DIFF
--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -8,6 +8,7 @@ import Carousel from "../shared/components/carousel/Carousel";
 import { useEffect, useState } from "react";
 import CarouselPrevButton from "../shared/components/carousel/CarouselPrevButton";
 import CarouselNextButton from "../shared/components/carousel/CarouselNextButton";
+import { ICartItem } from "@/modules/interfaces/products.interface";
 
 const CartPage = () => {
   const {
@@ -112,7 +113,7 @@ const CartPage = () => {
                 onNext={handleNext}
                 onPrev={handlePrev}
               >
-                {items.map((item) => (
+                {items.map((item: ICartItem) => (
                   <CartItem
                     key={item.id}
                     item={item}

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -5,9 +5,9 @@ import ProductInfo from "./components/ProductInfo";
 import Layout from "@/app/shared/components/Layout";
 import useFetch from "@/hooks/useFetch";
 import { IProductDetails } from "@/modules/interfaces/products.interface";
-import ProductCardSkeleton from "@/app/shared/components/ProductCardSkeleton";
 import ProductInfoSkeleton from "./components/ProductInfoSkeleton";
 import { Fragment } from "react";
+import ProductImagesPlaceholder from "./placeholders/ProductImagesPlaceholder";
 
 const ProductDetails = ({ params }: { params: { id: string } }) => {
   const { data, loading, error } = useFetch<IProductDetails>(
@@ -37,7 +37,6 @@ const ProductDetails = ({ params }: { params: { id: string } }) => {
                 </div>
 
                 {data && <ProductInfo key={data.id} products={data} />}
-
               </div>
             </div>
           </div>
@@ -47,7 +46,7 @@ const ProductDetails = ({ params }: { params: { id: string } }) => {
           <div className="container mx-auto lg:w-[80%] py-[5%]">
             <div className="flex flex-col lg:flex-row lg:justify-center lg:gap-[3%] items-start">
               <div className="flex flex-col lg:flex-row lg:w-2/4 w-full lg:p-6">
-                <ProductCardSkeleton />
+                <ProductImagesPlaceholder />
               </div>
 
               <div className="lg:w-[30%] w-full lg:p-6 lg:pt-10 pt-10 py-6 px-4 mt-6 lg:mt-0 border-2 border-[#D9D9D9]">

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -5,9 +5,9 @@ import ProductInfo from "./components/ProductInfo";
 import Layout from "@/app/shared/components/Layout";
 import useFetch from "@/hooks/useFetch";
 import { IProductDetails } from "@/modules/interfaces/products.interface";
-import ProductInfoSkeleton from "./components/ProductInfoSkeleton";
 import { Fragment } from "react";
 import ProductImagesPlaceholder from "./placeholders/ProductImagesPlaceholder";
+import ProductInfoPlaceholder from "./placeholders/ProductInfoSkeleton";
 
 const ProductDetails = ({ params }: { params: { id: string } }) => {
   const { data, loading, error } = useFetch<IProductDetails>(
@@ -50,7 +50,7 @@ const ProductDetails = ({ params }: { params: { id: string } }) => {
               </div>
 
               <div className="lg:w-[30%] w-full lg:p-6 lg:pt-10 pt-10 py-6 px-4 mt-6 lg:mt-0 border-2 border-[#D9D9D9]">
-                <ProductInfoSkeleton />
+                <ProductInfoPlaceholder />
               </div>
             </div>
           </div>

--- a/src/app/products/[id]/placeholders/ProductImagesPlaceholder.tsx
+++ b/src/app/products/[id]/placeholders/ProductImagesPlaceholder.tsx
@@ -1,0 +1,21 @@
+const ProductImagesPlaceholder = () => {
+  return (
+    <div className="flex flex-col lg:flex-row lg:w-full max-h-[500px] animate-pulse">
+      {/* Main image placeholder */}
+      <div className="w-full lg:w-3/4 mb-4">
+        <div className="w-full bg-gray-300 h-[200px] lg:h-[450px]"></div>
+      </div>
+
+      {/* Thumbnails placeholder */}
+      <div className="w-full lg:w-1/4 lg:flex lg:flex-col lg:items-center flex space-x-3 overflow-auto scrollbar-none">
+        <div className="flex lg:flex-col gap-2">
+          {[1, 2, 3, 4].map((_, idx) => (
+            <div key={idx} className="w-14 h-16 bg-gray-300"></div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProductImagesPlaceholder;

--- a/src/app/products/[id]/placeholders/ProductInfoSkeleton.tsx
+++ b/src/app/products/[id]/placeholders/ProductInfoSkeleton.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 
-const ProductInfoSkeleton = () => {
+const ProductInfoPlaceholder = () => {
   return (
     <Fragment>
       {/* Product Name Skeleton */}
@@ -36,4 +36,4 @@ const ProductInfoSkeleton = () => {
   );
 };
 
-export default ProductInfoSkeleton;
+export default ProductInfoPlaceholder;


### PR DESCRIPTION
- Change placeholder for product images on product details page

![image](https://github.com/user-attachments/assets/8a07dc94-1147-4f42-88f9-9f4c88a3932d)
